### PR TITLE
S3 Sync: Transpose Bucket and Documents Folder

### DIFF
--- a/scripts/ec2gaming.bat.template
+++ b/scripts/ec2gaming.bat.template
@@ -3,6 +3,6 @@ rmdir /Q /S  "C:\Program Files (x86)\Steam\steamapps"
 md Z:\SteamLibrary\steamapps
 cmd /c mklink /j "C:\Program Files (x86)\Steam\steamapps" Z:\SteamLibrary\steamapps
 md Z:\Documents
-aws s3 sync Z:\Documents s3://BUCKET/Documents
+aws s3 sync s3://BUCKET/Documents Z:\Documents
 if %errorlevel% neq 0 exit /b %errorlevel%
 schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://ec2gaming-639801188054/Documents --delete"


### PR DESCRIPTION
The initial sync in `ec2gaming.bat` needs to be from the S3 bucket to
`z:\Documents`.