### PR TITLE
Added in Region for S3 Sync

### DIFF
--- a/scripts/ec2gaming.bat.template
+++ b/scripts/ec2gaming.bat.template
@@ -3,6 +3,6 @@ rmdir /Q /S  "C:\Program Files (x86)\Steam\steamapps"
 md Z:\SteamLibrary\steamapps
 cmd /c mklink /j "C:\Program Files (x86)\Steam\steamapps" Z:\SteamLibrary\steamapps
 md Z:\Documents
-aws s3 sync Z:\Documents s3://BUCKET/Documents
+aws s3 sync Z:\Documents s3://BUCKET/Documents --region REGION
 if %errorlevel% neq 0 exit /b %errorlevel%
 schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://ec2gaming-639801188054/Documents --delete"

--- a/scripts/ec2gaming.bat.template
+++ b/scripts/ec2gaming.bat.template
@@ -5,4 +5,4 @@ cmd /c mklink /j "C:\Program Files (x86)\Steam\steamapps" Z:\SteamLibrary\steama
 md Z:\Documents
 aws s3 sync Z:\Documents s3://BUCKET/Documents --region REGION
 if %errorlevel% neq 0 exit /b %errorlevel%
-schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://ec2gaming-639801188054/Documents --delete"
+schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://ec2gaming-639801188054/Documents --delete --region REGION"


### PR DESCRIPTION
I noticed the sync script was not working correctly when testing in Frankfurt / Europe. It requires a specific `--region REGION`

Great work by the way!