### PR TITLE
Fix S3 syncing problems

### DIFF
--- a/scripts/ec2gaming.bat.template
+++ b/scripts/ec2gaming.bat.template
@@ -3,6 +3,6 @@ rmdir /Q /S  "C:\Program Files (x86)\Steam\steamapps"
 md Z:\SteamLibrary\steamapps
 cmd /c mklink /j "C:\Program Files (x86)\Steam\steamapps" Z:\SteamLibrary\steamapps
 md Z:\Documents
-aws s3 sync Z:\Documents s3://BUCKET/Documents
+aws s3 sync s3://BUCKET/Documents Z:\Documents
 if %errorlevel% neq 0 exit /b %errorlevel%
-schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://ec2gaming-639801188054/Documents --delete"
+schtasks /Create /RU USERNAME /RP PASSWORD /F /SC MINUTE /MO 1 /TN "Sync Documents with S3" /TR "aws s3 sync Z:\Documents s3://BUCKET/Documents --delete"


### PR DESCRIPTION
Initial sync changed to be from S3 bucket to Z:\Documents instead of
vice versa (which wipes the bucket every time). Added BUCKET placeholder
to be replaced by sed command when creating scheduled task (instead of
hardcoded bucket address which is not the one owned by the user).